### PR TITLE
Build wheels for Python 2.7 and 64 bit Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"

--- a/fetch-win32-wheels
+++ b/fetch-win32-wheels
@@ -16,7 +16,7 @@ fi
 niversion=$1
 artifact_url="https://ci.appveyor.com/api/projects/al45tair/netifaces/artifacts"
 win32_versions="27 34 35 36 37 38"
-amd64_versions="36 37 38"
+amd64_versions="27 36 37 38"
 
 for version in $win32_versions; do
     wheel=netifaces-$niversion-cp$version-cp${version}m-win32.whl


### PR DESCRIPTION
A fix for #47, hopefully.